### PR TITLE
major: upgrade to fastify v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,6 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v4.2.1
+    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v5.0.0
     with:
       lint: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,6 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v3
+    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v4.2.1
     with:
       lint: true

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ dist
 .tern-port
 package-lock.json
 .vscode/
+.tap/

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ dist
 package-lock.json
 .vscode/
 .tap/
+asd*

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # fastify-user-agent
 User-agent information plugin for Fastify.
 
-[![Build Status](https://github.com/Eomm/fastify-user-agent/workflows/ci/badge.svg)](https://github.com/Eomm/fastify-user-agent/actions)
 [![ci](https://github.com/Eomm/fastify-user-agent/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Eomm/fastify-user-agent/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/fastify-user-agent)](https://www.npmjs.com/package/fastify-user-agent)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # fastify-user-agent
 User-agent information plugin for Fastify.
 
-[![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 [![Build Status](https://github.com/Eomm/fastify-user-agent/workflows/ci/badge.svg)](https://github.com/Eomm/fastify-user-agent/actions)
+[![ci](https://github.com/Eomm/fastify-user-agent/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Eomm/fastify-user-agent/actions/workflows/ci.yml)
+[![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
 
 ## Install
@@ -15,6 +16,7 @@ npm install fastify-user-agent
 
 | Plugin version | Fastify version |
 | -------------- |:---------------:|
+| `^2.0.0`       | `^5.0.0`        |
 | `^1.0.0`       | `^4.0.0`        |
 
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function fastifyUserAgent (fastify, options, next) {
 }
 
 const plugin = fp(fastifyUserAgent, {
-  fastify: '^4.x',
+  fastify: '^5.x',
   name: 'fastify-user-agent'
 })
 

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
   },
   "homepage": "https://github.com/Eomm/fastify-user-agent#readme",
   "dependencies": {
-    "fastify-plugin": "^4.4.0",
+    "fastify-plugin": "^4.5.1",
     "useragent": "^2.3.0"
   },
   "devDependencies": {
-    "fastify": "^4.10.2",
-    "standard": "^17.0.0",
-    "tap": "^16.3.2"
+    "fastify": "^4.27.0",
+    "standard": "^17.1.0",
+    "tap": "^19.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   },
   "homepage": "https://github.com/Eomm/fastify-user-agent#readme",
   "dependencies": {
-    "fastify-plugin": "^5.0.0-pre.fv5.1",
+    "fastify-plugin": "^5.0.0",
     "useragent": "^2.3.0"
   },
   "devDependencies": {
-    "fastify": "^5.0.0-alpha.3",
+    "fastify": "^5.0.0",
     "standard": "^17.1.0",
     "tap": "^21.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "useragent"
   ],
   "author": "Manuel Spigolon <behemoth89@gmail.com> (https://github.com/Eomm)",
+  "funding": "https://github.com/Eomm/fastify-user-agent?sponsor=1",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Eomm/fastify-user-agent/issues"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "standard",
     "lint:fix": "standard --fix",
-    "test": "tap test/**/*.test.js"
+    "test": "tap --show-full-coverage"
   },
   "repository": {
     "type": "git",
@@ -25,12 +25,12 @@
   },
   "homepage": "https://github.com/Eomm/fastify-user-agent#readme",
   "dependencies": {
-    "fastify-plugin": "^4.5.1",
+    "fastify-plugin": "^5.0.0-pre.fv5.1",
     "useragent": "^2.3.0"
   },
   "devDependencies": {
-    "fastify": "^4.27.0",
+    "fastify": "^5.0.0-alpha.3",
     "standard": "^17.1.0",
-    "tap": "^19.2.2"
+    "tap": "^21.0.0"
   }
 }


### PR DESCRIPTION
This PR does not bump fastify v5, but it starts testing it with the new nodejs versions and upgrade the tap module.